### PR TITLE
Add email notification to organizers for registration change

### DIFF
--- a/app/controllers/conference_registrations_controller.rb
+++ b/app/controllers/conference_registrations_controller.rb
@@ -52,6 +52,7 @@ class ConferenceRegistrationsController < ApplicationController
     authorize! :create, @registration
 
     if @registration.save
+      RegistrationChangeNotificationMailJob.perform_later(@conference, @registration.user, 'create')
       # Trigger ahoy event
       ahoy.track 'Registered', title: 'New registration'
 
@@ -86,7 +87,9 @@ class ConferenceRegistrationsController < ApplicationController
   end
 
   def destroy
+    registration_user = @registration.user
     if @registration.destroy
+      RegistrationChangeNotificationMailJob.perform_later(@conference, registration_user, 'destroy')
       redirect_to root_path,
                   notice: "You are not registered for #{@conference.title} anymore!"
     else

--- a/app/jobs/registration_change_notification_mail_job.rb
+++ b/app/jobs/registration_change_notification_mail_job.rb
@@ -1,0 +1,10 @@
+class RegistrationChangeNotificationMailJob < ApplicationJob
+  queue_as :default
+
+  def perform(conference, registration_user, action)
+
+    User.registration_notifiable(conference).each do |recipient|
+      Mailbot.registration_change_notification_mail(conference, registration_user, action, recipient).deliver_now
+    end
+  end
+end

--- a/app/mailers/mailbot.rb
+++ b/app/mailers/mailbot.rb
@@ -117,15 +117,26 @@ class Mailbot < ActionMailer::Base
          body: conference.email_settings.generate_booth_mail(booth, conference.email_settings.booths_rejection_body))
   end
 
-  def registration_change_notification_mail(conference, registration_user, action, recipient)
+  def registration_change_notification_mail(conference, registration_user, action, recipient, coupon=nil)
     @recipient = recipient
     @registration_user = registration_user
     @conference = conference
     @registration_action = action
+    @coupon = coupon
+
+    subject = if action == 'create'
+               "New registration for #{registration_user.try(:name)} in #{conference.title}"
+              elsif action == 'destroy'
+                "Cancelled registration for #{registration_user.try(:name)} in #{conference.title}"
+              elsif action == 'apply_coupon'
+                "Coupon #{coupon.try(:name)} applied for #{registration_user.try(:name)} in #{conference.title}"
+              elsif action == 'remove_coupon'
+                "Coupon #{coupon.try(:name)} removed for #{registration_user.try(:name)} in #{conference.title}"
+              end
 
     mail(to: @recipient.email,
          from: @conference.contact.email,
-         subject: "Registration changes for user #{registration_user.try(:name)} in #{conference.title}",
+         subject: subject,
          template_name: 'registration_change_notification_template')
   end
 

--- a/app/mailers/mailbot.rb
+++ b/app/mailers/mailbot.rb
@@ -117,6 +117,18 @@ class Mailbot < ActionMailer::Base
          body: conference.email_settings.generate_booth_mail(booth, conference.email_settings.booths_rejection_body))
   end
 
+  def registration_change_notification_mail(conference, registration_user, action, recipient)
+    @recipient = recipient
+    @registration_user = registration_user
+    @conference = conference
+    @registration_action = action
+
+    mail(to: @recipient.email,
+         from: @conference.contact.email,
+         subject: "Registration changes for user #{registration_user.try(:name)} in #{conference.title}",
+         template_name: 'registration_change_notification_template')
+  end
+
   def event_comment_mail(comment, user)
     @comment = comment
     @event = @comment.commentable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ApplicationRecord
 
   # add scope
   scope :comment_notifiable, ->(conference) {joins(:roles).where('roles.name IN (?)', [:organizer, :cfp]).where('roles.resource_type = ? AND roles.resource_id = ?', 'Conference', conference.id)}
+  scope :registration_notifiable, ->(conference) {joins(:roles).where('roles.name IN (?)', [:organizer, :info_desk]).where('roles.resource_type = ? AND roles.resource_id = ?', 'Conference', conference.id)}
 
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,

--- a/app/views/mailbot/registration_change_notification_template.html.haml
+++ b/app/views/mailbot/registration_change_notification_template.html.haml
@@ -9,6 +9,10 @@ user
   registered to attend #{@conference.title}
 - elsif @registration_action == 'destroy'
   unregistered from #{@conference.title}.
+- elsif @registration_action == 'apply_coupon'
+  applied #{@coupon.try(:name)} in #{@conference.title}
+- elsif @registration_action == 'remove_coupon'
+  removed #{@coupon.try(:name)} in #{@conference.title}
 
 %br
 %br

--- a/app/views/mailbot/registration_change_notification_template.html.haml
+++ b/app/views/mailbot/registration_change_notification_template.html.haml
@@ -1,0 +1,16 @@
+Dear #{@recipient.name},
+%br
+%br
+
+user
+= link_to @registration_user.try(:name), admin_user_url(@registration_user)
+
+- if @registration_action == 'create'
+  registered to attend #{@conference.title}
+- elsif @registration_action == 'destroy'
+  unregistered from #{@conference.title}.
+
+%br
+%br
+%br
+%i This is an automated email, and you are receiving it because you are part of the #{@conference.title} team.

--- a/dotenv.example
+++ b/dotenv.example
@@ -84,3 +84,5 @@ RECAPTCHA_SECRET_KEY=""
 
 # The url of the redis server
 OSEM_REDIS_URL='redis://localhost:6379/1'
+
+OSEM_REGISTRATION_NOTIFICATION=false


### PR DESCRIPTION
Users with the role of organizer or info_desk will receive an email when:

- [x] user registers for the conference
- [x] user unregisters from the conference
- [x] user adds registration code
- [x] user removes registration code

Demo: https://eurobsdcon-pr-2.herokuapp.com/conferences/osemdemo/register
Actually receiving an email to your mailbox will take a couple of minutes.
The notification email goes to the organizer, currently that's the admin user and the email goes to my mailbox. A new user can be register with someone else's email address, to see this work in action.

![screenshot from 2018-04-12 17-07-30](https://user-images.githubusercontent.com/4322737/38682545-053b6e46-3e74-11e8-82e3-ec183cd5f842.png)
![screenshot from 2018-04-12 17-07-24](https://user-images.githubusercontent.com/4322737/38682548-0708c912-3e74-11e8-940f-9c636c9a6bb3.png)
