### PR TITLE
Show user page if user is a speaker

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,7 +33,11 @@ class Ability
 
     # can view Commercials of confirmed Events
     can :show, Commercial, commercialable_type: 'Event', commercialable_id: Event.where(state: 'confirmed').pluck(:id)
-    can [:show, :create], User
+    can [:create], User
+    can :show, User do |user|
+      user.presented_events.confirmed.any?
+    end
+
     unless ENV['OSEM_ICHAIN_ENABLED'] == 'true'
       can :show, Registration do |registration|
         registration.new_record?


### PR DESCRIPTION
Allows not signed in user to view another user's profile, only if the profile belongs to a user that is a speaker to any conference in the OSEM instance.

Speaker means the user has at least one talk which is accepted and **confirmed** (even if it is not scheduled yet).

On a similar note, registered users show up in
https://registration.eurobsdcon.org/conferences/2018/register