### PR TITLE
Show link only if speaker in registrations#show

### DIFF
--- a/app/views/conference_registrations/show.html.haml
+++ b/app/views/conference_registrations/show.html.haml
@@ -137,7 +137,10 @@
           Registered
           = word_pluralize(@conference.participants.count, 'Attendee')
         - @conference.participants.each do |participant|
-          = link_to image_tag(participant.gravatar_url(size: '25'), title: "#{participant.name}!", class: 'img-circle'), user_path(participant)
+          - if can? :show, participant
+            = link_to image_tag(participant.gravatar_url(size: '25'), title: "#{participant.name}!", class: 'img-circle'), user_path(participant)
+          - else
+            = image_tag(participant.gravatar_url(size: '25'))
     .col-md-4.col-md-offset-2
       - if @conference.program.speakers.confirmed.any?
         %h4


### PR DESCRIPTION
Show image_tag for registered users in registrations#show.
Link to user only if user has been a speaker in any conference in osem instance.